### PR TITLE
Switch from plyr::rbind.fill to dplyr::bind_rows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Depends:
   R (>= 3.0.1)
 Imports:
   stats,
-  plyr,
+  dplyr (>= 0.5.0),
   httr,
   jsonlite
 License: MIT + file LICENSE

--- a/R/idig_build_attrib.R
+++ b/R/idig_build_attrib.R
@@ -24,7 +24,7 @@ idig_build_attrib <- function(dat){
       uuid <- datAt$attribution[[i]]$uuid
       itemCount <- datAgg$count[datAgg$recordset == datAt$attribution[[i]]$uuid]
       rows <- cbind(data.frame(collection,stringsAsFactors = FALSE),data.frame(uuid,stringsAsFactors = FALSE),data.frame(itemCount,stringsAsFactors = FALSE))
-      dx <- plyr::rbind.fill(dx,rows)
+      dx <- dplyr::bind_rows(dx,rows)
     }
 
   }

--- a/R/idig_search.R
+++ b/R/idig_search.R
@@ -100,7 +100,7 @@ idig_search <- function(type="records", mq=FALSE, rq=FALSE, fields=FALSE,
                   " Please see https://github.com/iDigBio/ridigbio/issues/33"))
     }
     
-    dat <- plyr::rbind.fill(dat, fmt_search_txt_to_df(search_results, fields))
+    dat <- dplyr::bind_rows(dat, fmt_search_txt_to_df(search_results, fields))
 
     query$offset <- nrow(dat)
     if (limit > 0){


### PR DESCRIPTION
I consistently receive the following warning message when running `idig_search_records`:

```
Warning message:
    In column[rows] <<- what :
    number of items to replace is not a multiple of replacement length
```

It seems to be related to the use of `plyr::rbind.fill` in the `idig_search` function.  Switching to its more current counterpart, `dplyr::bind_rows` seemingly solves the problem.  I'm not sure if/how the switch to `dplyr::bind_rows` influences the geopoint massaging that occurs in the `fmt_search_txt_to_df` function.

MRE:
```
rq <- list(geopoint = list(type = "geo_bounding_box",
                           top_left = list(lat = 31.53, lon = -81.21),
                           bottom_right = list(lat = 31.45, lon = -81.19)))
idb_recs <- ridigbio::idig_search_records(rq = rq, fields = "all")

```

