### PR TITLE
Updated for R version 4.2.1

### DIFF
--- a/R/base.R
+++ b/R/base.R
@@ -65,7 +65,7 @@ idig_check <- function(req) {
 ##' @author Francois Michonneau
 idig_check_error <- function(req) {
   cont <- httr::content(req)
-  if (is.list(cont) && exists("error", cont)) {
+  if (is.list(cont) & exists("error", cont)) {
     stop(paste("Error: ", cont$error, "\n", sep = ""))
   }
 }

--- a/R/idig_count_media.R
+++ b/R/idig_count_media.R
@@ -14,11 +14,11 @@ idig_count_media <- function(rq=FALSE, mq=FALSE, ...){
   # empty if the user doesn't specify anything
   query <- list()
 
-  if (inherits(rq, "list") && length(rq) > 0){
+  if (inherits(rq, "list") & length(rq) > 0){
     query$rq <- rq
   }
 
-  if (inherits(mq, "list") && length(mq) > 0){
+  if (inherits(mq, "list") & length(mq) > 0){
     query$mq <- mq
   }
 

--- a/R/idig_count_records.R
+++ b/R/idig_count_records.R
@@ -14,7 +14,7 @@ idig_count_records <- function(rq=FALSE, ...){
   # empty if the user doesn't specify anything
   query <- list()
 
-  if (inherits(rq, "list") && length(rq) > 0){
+  if (inherits(rq, "list") & length(rq) > 0){
     query$rq <- rq
   }
 

--- a/R/idig_search.R
+++ b/R/idig_search.R
@@ -87,14 +87,14 @@ idig_search <- function(type="records", mq=FALSE, rq=FALSE, fields=FALSE,
   item_count <- 1
 
   # loop until we either have all results or all results the user wants
-  while (nrow(dat) < item_count && (limit == 0 || nrow(dat) < limit)){
+  while (nrow(dat) < item_count & (limit == 0 | nrow(dat) < limit)){
     search_results <- idig_POST(paste0("search/", type), body=query, ...)
     #print(paste0(Sys.time(), " completed query"))
     # Slight possibility of the number of items changing as we go due to inserts
     # deletes at iDigBio, put this inside the loop to keep it current
     item_count <- fmt_search_txt_to_itemCount(search_results)
 
-    if ((limit == 0 || limit > max_items) && item_count > max_items){
+    if ((limit == 0 | limit > max_items) & item_count > max_items){
       stop(paste0("Search would return more than 100,000",
                   " results. This functionality is currently disabled.",
                   " Please see https://github.com/iDigBio/ridigbio/issues/33"))
@@ -178,7 +178,7 @@ build_field_lists <- function(fields, type) {
   ret <- list()
   ret$query = list()
   # Here Alex says to eat "all" rather than pass it through to the API
-  if (inherits(fields, "character") && fields != "all" && length(fields) > 0 ){
+  if (inherits(fields, "character") & !("all" %in% fields) & length(fields) > 0 ){
     ret$fields <- fields
     ret$query$fields <- fields
   } else {

--- a/R/idig_search_media.R
+++ b/R/idig_search_media.R
@@ -43,15 +43,15 @@ idig_search_media <- function(mq=FALSE, rq=FALSE, fields=FALSE,
   # Validate inputs
   #if (!(inherits(rq, "list"))) { stop("rq is not a list") }
 
-  if (!(length(rq) > 0) && !(length(rq) > 0)) {
+  if (!(length(rq) > 0) & !(length(rq) > 0)) {
     stop("mq or rq must not be 0 length")
   }
 
-  if (inherits(fields, "logical") && fields == FALSE) {
+  if (inherits(fields, "logical") & fields == FALSE) {
     fields <- DEFAULT_FIELDS
   }
 
-  if (!(fields == "all" ) && !(inherits(fields, "character"))) {
+  if (!(fields == "all" ) & !(inherits(fields, "character"))) {
     stop("Invalid value for fields")
   }
 

--- a/R/idig_search_records.R
+++ b/R/idig_search_records.R
@@ -139,11 +139,11 @@ idig_search_records <- function(rq, fields=FALSE, max_items=100000, limit=0,
 
   if (!(length(rq) > 0)) { stop("rq must not be 0 length") }
 
-  if (inherits(fields, "logical") && fields == FALSE) {
+  if (inherits(fields, "logical") & fields == FALSE) {
     fields <- DEFAULT_FIELDS
   }
 
-  if (!(fields == "all" ) && !(inherits(fields, "character"))) {
+  if (!(fields == "all" ) & !(inherits(fields, "character"))) {
     stop("Invalid value for fields")
   }
 

--- a/R/idig_search_records.R
+++ b/R/idig_search_records.R
@@ -142,8 +142,7 @@ idig_search_records <- function(rq, fields=FALSE, max_items=100000, limit=0,
   if (inherits(fields, "logical") & fields == FALSE) {
     fields <- DEFAULT_FIELDS
   }
-
-  if (!(fields == "all" ) & !(inherits(fields, "character"))) {
+  if (!("all" %in% fields) & !(inherits(fields, "character"))) {
     stop("Invalid value for fields")
   }
 

--- a/R/idig_top_media.R
+++ b/R/idig_top_media.R
@@ -21,15 +21,15 @@ idig_top_media <- function(rq=FALSE, mq=FALSE, top_fields=FALSE, count=0, ...){
   # empty if the user doesn't specify anything
   query <- list()
 
-  if (inherits(rq, "list") && length(rq) > 0){
+  if (inherits(rq, "list") & length(rq) > 0){
     query$rq <- rq
   }
 
-  if (inherits(mq, "list") && length(mq) > 0){
+  if (inherits(mq, "list") & length(mq) > 0){
     query$mq <- mq
   }
 
-  if (inherits(top_fields, "character") && length(top_fields) > 0){
+  if (inherits(top_fields, "character") & length(top_fields) > 0){
     query$top_fields <- top_fields
   }
 

--- a/R/idig_top_records.R
+++ b/R/idig_top_records.R
@@ -21,11 +21,11 @@ idig_top_records <- function(rq=FALSE, top_fields=FALSE, count=0, ...){
   # empty if the user doesn't specify anything
   query <- list()
 
-  if (inherits(rq, "list") && length(rq) > 0){
+  if (inherits(rq, "list") & length(rq) > 0){
     query$rq <- rq
   }
 
-  if (inherits(top_fields, "character") && length(top_fields) > 0){
+  if (inherits(top_fields, "character") & length(top_fields) > 0){
     query$top_fields <- top_fields
   }
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ On Linux, you may encounter an error during the installation process if you do n
 # Basic usage
 
     library("ridigbio")
-    idig_search_records(rq=list(genus="acer"))
+    idig_search_records(rq=list(genus="galax"))
     idig_search_records(rq=list(family="holothuriidae"), limit=1000)
 
 Complete list of terms that can be used is available [here](https://github.com/iDigBio/idigbio-search-api/wiki/Index-Fields#record-query-fields)


### PR DESCRIPTION
Error messages begin with R Version 4.2.1. I was able to remove all errors with some simple modifications: If statements are revised to be the length of 1, duplicate "&" and "|" are removed, and the example changed on README to be <10,000 records.